### PR TITLE
Fix sync issues when accepting code hint in inline editor

### DIFF
--- a/main.js
+++ b/main.js
@@ -147,13 +147,16 @@ define(function (require, exports, module) {
                     actualCompletion = stringChar + actualCompletion + stringChar;
                 }
 
-                
+                // HACK: We talk to the private CodeMirror instance directly to replace the range
+                // instead of using the Document, as we should. The reason is due to a flaw in our
+                // current document synchronization architecture when inline editors are open.
+                // *** (FILE BUG)
                 if (token.className === "string" || token.className === "number") { // replace
-                    editor.document.replaceRange(actualCompletion,
+                    editor._codeMirror.replaceRange(actualCompletion,
                                                  {line: cursor.line, ch: token.start},
                                                  {line: cursor.line, ch: token.end});
                 } else { // insert
-                    editor.document.replaceRange(actualCompletion, cursor);
+                    editor._codeMirror.replaceRange(actualCompletion, cursor);
                 }
             }
         }

--- a/main.js
+++ b/main.js
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
                 // HACK: We talk to the private CodeMirror instance directly to replace the range
                 // instead of using the Document, as we should. The reason is due to a flaw in our
                 // current document synchronization architecture when inline editors are open.
-                // *** (FILE BUG)
+                // See #1688.
                 if (token.className === "string" || token.className === "number") { // replace
                     editor._codeMirror.replaceRange(actualCompletion,
                                                  {line: cursor.line, ch: token.start},


### PR DESCRIPTION
Because of adobe/brackets#1688, there is a general bug where edits in a master editor during an operation started in an inline editor cause syncing problems. This happens in the case of EWF code hints as described in #19. In this scenario, when the user hits enter in the code hint menu in an inline editor, the onKeyDown event starts an outer CodeMirror operation(), but EWF then edits the underlying document, which is really the master editor (not the inline editor). This hits the case described in adobe/brackets#1688.

The workaround for now is to simply make it so EWF does its edit in the editor it was called from, not the underlying document. It seems relatively safe and doesn't require changes to core Brackets code.
