### PR TITLE
re-center fonts after ewf service change

### DIFF
--- a/styles/ewf-brackets.less
+++ b/styles/ewf-brackets.less
@@ -182,7 +182,7 @@
             border: 1px solid #b4b6b5;
             border-radius: 3px;
             background-color: white;
-            background-position: center 5px;
+            background-position: 50% -20px;
             cursor: pointer;
             &.selected {
                 //box-shadow: 0 0 15px rgba(0,0,0,0.48);   
@@ -200,6 +200,7 @@
             border-top: 1px solid #b4b6b5;
             border-bottom-right-radius: 3px;
             border-bottom-left-radius: 3px;
+            overflow: hidden;
         }
         
         .ewf-font-details label {


### PR DESCRIPTION
EWF re-rendered their font previews. Change LESS to make them centered again.

Also, change overflow on font details so really long font names don't hang over. Long term, we should truncate these with ellipses.
