### PR TITLE
add "Terms of Use" link to browse dialog

### DIFF
--- a/htmlContent/ewf-browse-dialog.html
+++ b/htmlContent/ewf-browse-dialog.html
@@ -7,6 +7,7 @@
         <div class="edge-web-fonts edge-web-fonts-browse-dialog-body"></div>
     </div>
     <div class="modal-footer">
+        <span class="ewf-terms-of-use">{{{TERMS_OF_USE}}}</span>
         <a href="#" class="dialog-button btn primary" data-button-id="ok">{{DIALOG_DONE}}</a>
     </div>
 </div>

--- a/htmlContent/ewf-howto-dialog.html
+++ b/htmlContent/ewf-howto-dialog.html
@@ -13,6 +13,7 @@
         </ol>
     </div>
     <div class="modal-footer">
+        <span class="ewf-terms-of-use">{{{Strings.TERMS_OF_USE}}}</span>
         <a href="#" class="dialog-button btn primary" data-button-id="ok">{{Strings.DIALOG_DONE}}</a>
     </div>
 </div>

--- a/htmlContent/ewf-include-dialog.html
+++ b/htmlContent/ewf-include-dialog.html
@@ -9,6 +9,7 @@
         <textarea rows="3" readonly="readonly" class="ewf-include-string"></textarea>
     </div>
     <div class="modal-footer">
+        <span class="ewf-terms-of-use">{{{TERMS_OF_USE}}}</span>
         <a href="#" class="dialog-button btn primary" data-button-id="ok">{{DIALOG_DONE}}</a>
     </div>
 </div>

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -38,7 +38,7 @@ define({
     "HOWTO_INSTRUCTIONS_2"           : "When specifying a font-family property in a CSS document, select 'Browse Web Fonts' from the code completion drop-down to browse for free online web fonts.",
     "HOWTO_INSTRUCTIONS_3"           : "When you're done, click the [ Wf ] icon in the top right to generate the required embed code.",
     "HOWTO_INSTRUCTIONS_4"           : "Paste the embed code into any HTML page to include the fonts.",
-    "TERMS_OF_USE"                   : "Edge Web Fonts <a class=\"clickable-link\" data-href=\"http://www.adobe.com/products/eulas/tou_typekit/\">Terms of Use</a>",
+    "TERMS_OF_USE"                   : "Edge Web Fonts <a class=\"clickable-link\" data-href=\"http://adobe.com/go/edgewebfonts_tou\">Terms of Use</a>",
     
     
     // Font classifications

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -38,6 +38,7 @@ define({
     "HOWTO_INSTRUCTIONS_2"           : "When specifying a font-family property in a CSS document, select 'Browse Web Fonts' from the code completion drop-down to browse for free online web fonts.",
     "HOWTO_INSTRUCTIONS_3"           : "When you're done, click the [ Wf ] icon in the top right to generate the required embed code.",
     "HOWTO_INSTRUCTIONS_4"           : "Paste the embed code into any HTML page to include the fonts.",
+    "TERMS_OF_USE"                   : "Edge Web Fonts <a class=\"clickable-link\" data-href=\"http://www.adobe.com/products/eulas/tou_typekit/\">Terms of Use</a>",
     
     
     // Font classifications

--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -254,6 +254,11 @@
 .edge-web-fonts-browse-dialog .modal-footer {
   clear: both;
 }
+.edge-web-fonts-browse-dialog .ewf-terms-of-use {
+  position: relative;
+  top: 7px;
+  left: 3px;
+}
 .edge-web-fonts-include-dialog textarea {
   width: 550px;
   resize: none;

--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -254,7 +254,9 @@
 .edge-web-fonts-browse-dialog .modal-footer {
   clear: both;
 }
-.edge-web-fonts-browse-dialog .ewf-terms-of-use {
+.edge-web-fonts-browse-dialog .ewf-terms-of-use,
+.edge-web-fonts-include-dialog .ewf-terms-of-use,
+.edge-web-fonts-howto-dialog .ewf-terms-of-use {
   position: relative;
   top: 7px;
   left: 3px;


### PR DESCRIPTION
@adrocknaphobia We need to determine if we need the Terms of Use link needs to be translated to French. My hunch is "yes", since we translated a similar string in the Brackets about dialog. I've set it up so that it can easily be translated.
