### PR TITLE
Update for the new code hinting API

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,13 +95,13 @@ define(function (require, exports, module) {
      */
     function _augmentCodeHintUI() {
 
-        function repositionAddition(list, addition) {
-            var menuListPosition = list.position();
-            addition.css("position", "absolute");
-            addition.css("top", menuListPosition.top + list.height());
-            addition.css("left", menuListPosition.left);
-            addition.css("width", list.width());
-            addition.css("max-width", list.width());
+        function repositionAddition($list, $addition) {
+            var menuListPosition = $list.position();
+            $addition.css("position", "absolute");
+            $addition.css("top", menuListPosition.top + $list.height());
+            $addition.css("left", menuListPosition.left);
+            $addition.css("width", $list.width());
+            $addition.css("max-width", $list.width());
         }
 
         var $menu = $(".dropdown.codehint-menu.open");


### PR DESCRIPTION
Addresses issue #56 by updating the EWF extension to use the new [code hinting API](https://github.com/adobe/brackets/wiki/New-Code-Hinting-API-Proposal). 

Note that for this pull request only simple, unformatted hints are used so as to narrowly address #56. A subsequent pull request (#58) makes use of the jQuery formatting capabilities (enabled by adobe/brackets#2427) of the new code hint API to also format the font hints using the associated font family. 
