### PR TITLE
Calculate the matched portion of candidate hints, as emphasized in the hint list, insensitive to case.

### DIFF
--- a/main.js
+++ b/main.js
@@ -276,6 +276,7 @@ define(function (require, exports, module) {
         var editor = this.editor,
             cursor = editor.getCursorPos(),
             query,
+            lowerCaseQuery,
             token;
         
         if (_documentIsCSS(editor.document)) {
@@ -296,6 +297,9 @@ define(function (require, exports, module) {
                     query = "";
                 }
 
+                // candidate hints are lower case, so the query should be too
+                lowerCaseQuery = query.toLocaleLowerCase();
+
                 // we're going to handle this query, so we need to add our UI
                 setTimeout(_augmentCodeHintUI, 1);
 
@@ -305,7 +309,7 @@ define(function (require, exports, module) {
                 candidates = webfont.lowerSortUniqStringArray(candidates);
                 candidates = webfont.filterAndSortArray(query, candidates);
                 candidates = candidates.map(function (hint) {
-                    var index       = hint.indexOf(query),
+                    var index       = hint.indexOf(lowerCaseQuery),
                         $hintObj    = $('<span>'),
                         slugs       = webfont.searchBySlug(hint);
 


### PR DESCRIPTION
This changes how the emphasized part of each candidate hint is calculated. With this change, matches are calculated w.r.t. an eponymous variable `lowerCaseQuery`, instead of the possibly-mixed-case `query` variable, for case-insensitive compatibility with the lower-case hints returned from the `filterAndSortArray` function. Addresses #71.
