### PR TITLE
Replaced EditorUtils with LanguageManager in anticipation of Sprint 21

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
         StringUtils             = brackets.getModule("utils/StringUtils"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),
         EditorManager           = brackets.getModule("editor/EditorManager"),
-        EditorUtils             = brackets.getModule("editor/EditorUtils"),
+        Languages               = brackets.getModule("language/LanguageManager"),
         PreferencesManager      = brackets.getModule("preferences/PreferencesManager"),
         CodeHintManager         = brackets.getModule("editor/CodeHintManager"),
         CommandManager          = brackets.getModule("command/CommandManager"),
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
     var scriptCache = {};
     
     function _documentIsCSS(doc) {
-        return doc && EditorUtils.getModeFromFileExtension(doc.file.fullPath) === "css";
+        return doc && Languages.getLanguageForFileExtension(doc.file.fullPath).mode === "css";
     }
     
     /** Adds an option to browse EWF to the bottom of the code hint list


### PR DESCRIPTION
This shouldn't be merged until Sprint 21 lands but it replaces the EditorUtils with the LanguageManager. 
