### PR TITLE
Show hints when editing CSS code embedded in <style>...</style>

### DIFF
--- a/cssFontParser.js
+++ b/cssFontParser.js
@@ -87,8 +87,8 @@ define(function (require, exports, module) {
     function getFontTokenAtCursor(editor, cursor) {
         var cm = editor._codeMirror;
         var currentToken = cm.getTokenAt(cursor);
-	var stateStack = currentToken.state.stack? currentToken.state.stack: 
-	                                           currentToken.state.localState.stack;
+        var stateStack = currentToken.state.stack? currentToken.state.stack: 
+                                                   currentToken.state.localState.stack;
         var t, c;
         var result = null;
         

--- a/cssFontParser.js
+++ b/cssFontParser.js
@@ -87,6 +87,8 @@ define(function (require, exports, module) {
     function getFontTokenAtCursor(editor, cursor) {
         var cm = editor._codeMirror;
         var currentToken = cm.getTokenAt(cursor);
+	var stateStack = currentToken.state.stack? currentToken.state.stack: 
+	                                           currentToken.state.localState.stack;
         var t, c;
         var result = null;
         
@@ -95,8 +97,8 @@ define(function (require, exports, module) {
         // rules start with a "variable" token, then a ":", then values. We only want
         // autocomplete if we're somewhere after the ":"
         if (currentToken.className !== "property" && currentToken.className !== "property error" &&
-                currentToken.state.stack.length > 0 &&
-                currentToken.state.stack[currentToken.state.stack.length - 1] === "propertyValue") {
+                stateStack.length > 0 &&
+                stateStack[stateStack.length - 1] === "propertyValue") {
             
             // We're in a rule body. Step backwards until we find the most recent 
             // "variable" or are no longer in a rule (the latter, stepping out of the rule, 
@@ -105,8 +107,8 @@ define(function (require, exports, module) {
             t = currentToken;
             c = {ch: cursor.start, line: cursor.line};
             while (t.className !== "property" && t.className !== "property error" &&
-                    currentToken.state.stack.length > 0 &&
-                    currentToken.state.stack[currentToken.state.stack.length - 1] === "propertyValue") {
+                    stateStack.length > 0 &&
+                    stateStack[stateStack.length - 1] === "propertyValue") {
                 c.ch = t.start - 1;
                 if (c.ch < 0) {
                     // need to go up a line

--- a/main.js
+++ b/main.js
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
     }
 
     function _contextIsCSS(editor) {
-	return editor && editor.getLanguageForSelection().getName() == "CSS";
+        return editor && editor.getLanguageForSelection().getName() == "CSS";
     }
     
     /** Adds an option to browse EWF to the bottom of the code hint list

--- a/main.js
+++ b/main.js
@@ -78,6 +78,10 @@ define(function (require, exports, module) {
     function _documentIsCSS(doc) {
         return doc && doc.getLanguage().getName() === "CSS";
     }
+
+    function _contextIsCSS(editor) {
+	return editor && editor.getLanguageForSelection().getName() == "CSS";
+    }
     
     /** Adds an option to browse EWF to the bottom of the code hint list
      *
@@ -154,7 +158,7 @@ define(function (require, exports, module) {
         var actualCompletion = completion;
         var stringChar = "\"";
         
-        if (_documentIsCSS(editor.document)) { // on the off-chance we changed documents, don't change anything
+        if (_contextIsCSS(editor)) { // on the off-chance we changed documents, don't change anything
             token = parser.getFontTokenAtCursor(editor, cursor);
             if (token) {
                 // get the correct string character if there is already one in use
@@ -237,7 +241,7 @@ define(function (require, exports, module) {
      */
     FontHints.prototype.hasHints = function (editor, implicitChar) {
         this.editor = editor;
-        if (_documentIsCSS(editor.document)) {
+        if (_contextIsCSS(editor)) {
             if (!implicitChar) {
                 if (parser.getFontTokenAtCursor(editor, editor.getCursorPos())) {
                     return true;
@@ -278,7 +282,7 @@ define(function (require, exports, module) {
             lowerCaseQuery,
             token;
         
-        if (_documentIsCSS(editor.document)) {
+        if (_contextIsCSS(editor)) {
             token = parser.getFontTokenAtCursor(editor, cursor);
             if (token) {
                 if (token.className === "string") { // is wrapped in quotes        


### PR DESCRIPTION
This patch tries to resolve issue #81 by enabling edge-web-fonts to work in mixed html mode, however it does not show active icon nor handle toolbar clicks in HTML docs.
