### PR TITLE
Use the new icon in place of [ Wf ] in the howto dialog

### DIFF
--- a/htmlContent/ewf-howto-dialog.html
+++ b/htmlContent/ewf-howto-dialog.html
@@ -8,7 +8,7 @@
         <div class="edge-web-fonts-howto-diagram"></div>
         <ol>
             <li>{{Strings.HOWTO_INSTRUCTIONS_2}}</li>
-            <li>{{Strings.HOWTO_INSTRUCTIONS_3}}</li>
+            <li>{{{Strings.HOWTO_INSTRUCTIONS_3}}}</li>
             <li>{{Strings.HOWTO_INSTRUCTIONS_4}}</li>
         </ol>
     </div>

--- a/nls/de/strings.js
+++ b/nls/de/strings.js
@@ -36,7 +36,7 @@ define({
     "INCLUDE_INSTRUCTIONS_2"         : "Kopieren Sie den folgenden 'Script-Tag' und fügen Sie ihn in alle HTML-Dateien ein, auf welche sich diese CSS-Datei bezieht:",
     "HOWTO_INSTRUCTIONS_1"           : "Edge Web Fonts bietet Ihnen Zugriff auf eine Bibliothek von Web-Fonts, ermöglicht durch Beiträge von Adobe, Google und Designern auf der ganzen Welt. Die Schriften werden ausgeliefert von Typekit, kostenlos für die Nutzung auf ihrer Webseite.",
     "HOWTO_INSTRUCTIONS_2"           : "Beim definieren eines font-family Attributs in einem CSS Dokument, bitte 'Web-Fonts durchsuchen' aus dem Autovervollständigungs-Dialog auswählen um die kostenlosen Web-Fonts zu durchsuchen.",
-    "HOWTO_INSTRUCTIONS_3"           : "Wenn Sie fertig sind, klicken Sie auf das [ Wf ] Icon oben rechts um den benötigten Einbettungscode zu generieren.",
+    "HOWTO_INSTRUCTIONS_3"           : "Wenn Sie fertig sind, klicken Sie auf das <div class='instructions-icon'></div> Icon oben rechts um den benötigten Einbettungscode zu generieren.",
     "HOWTO_INSTRUCTIONS_4"           : "Fügen Sie den Einbettungscode in jede HTML-Seite ein um die Schriften zu integrieren.",
     "TERMS_OF_USE"                   : "<a class=\"clickable-link\" data-href=\"http://adobe.com/go/edgewebfonts_tou\">Edge Web Fonts Nutzungsbedingungen</a>",
     "SAMPLE_TEXT"                    : "Beispiel",

--- a/nls/fr/strings.js
+++ b/nls/fr/strings.js
@@ -36,7 +36,7 @@ define({
 	"INCLUDE_INSTRUCTIONS_2": "Copiez la balise de script qui suit, et collez-la dans tous les fichiers HTML qui font référence à ce fichier CSS :",
 	"HOWTO_INSTRUCTIONS_1": "Edge Web Fonts vous propose une bibliothèque de polices Web constituée par Adobe, Google et des créateurs du monde entier. Ces polices sont fournies par Typekit et peuvent être utilisées gratuitement sur votre site Web.",
 	"HOWTO_INSTRUCTIONS_2": "Lorsque vous définissez une propriété de famille de polices dans un document CSS, sélectionnez l’option Parcourir les polices Web dans la liste déroulante de définition du code afin d’accéder aux polices Web disponibles gratuitement en ligne.",
-	"HOWTO_INSTRUCTIONS_3": "Lorsque vous avez terminé, cliquez sur l’icône [ Wf ] dans l’angle supérieur droit afin de générer le code d’intégration requis.",
+	"HOWTO_INSTRUCTIONS_3": "Lorsque vous avez terminé, cliquez sur l’icône <div class='instructions-icon'></div> dans l’angle supérieur droit afin de générer le code d’intégration requis.",
 	"HOWTO_INSTRUCTIONS_4": "Collez ce code d’intégration dans une page HTML afin d’inclure les polices.",
     "HOWTO_DIAGRAM_IMAGE"            : "img/ewf-howto-dialog-fr.png",
     "HOWTO_DIAGRAM_IMAGE_HIDPI"      : "img/ewf-howto-dialog-fr@2x.png",

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -36,7 +36,7 @@ define({
     "INCLUDE_INSTRUCTIONS_2"         : "Copy the following script tag and paste it into all HTML files that reference this CSS file:",
     "HOWTO_INSTRUCTIONS_1"           : "Edge Web Fonts gives you access to a library of web fonts made possible by contributions from Adobe, Google, and designers around the world. The fonts are served by Typekit, free for use on your website.",
     "HOWTO_INSTRUCTIONS_2"           : "When specifying a font-family property in a CSS document, select 'Browse Web Fonts' from the code completion drop-down to browse for free online web fonts.",
-    "HOWTO_INSTRUCTIONS_3"           : "When you're done, click the [ Wf ] icon in the top right to generate the required embed code.",
+    "HOWTO_INSTRUCTIONS_3"           : "When you're done, click the <div class='instructions-icon'></div> icon in the top right to generate the required embed code.",
     "HOWTO_INSTRUCTIONS_4"           : "Paste the embed code into any HTML page to include the fonts.",
     "HOWTO_DIAGRAM_IMAGE"            : "img/ewf-howto-dialog-en.png",
     "HOWTO_DIAGRAM_IMAGE_HIDPI"      : "img/ewf-howto-dialog-en@2x.png",

--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -280,6 +280,13 @@
 .edge-web-fonts-howto-dialog .dialog-message {
   margin-bottom: 0px;
 }
+.edge-web-fonts-howto-dialog .instructions-icon {
+    background: no-repeat -webkit-image-set(url("../img/webfonts_icon.png") 1x, url("../img/webfonts_icon@2x.png") 2x);
+    display: inline-block;
+    width: 21px;
+    height: 15px;
+    margin-top: -2px;
+}
 
 .edge-web-fonts-howto-diagram {
     width: 531px;
@@ -328,4 +335,3 @@
   border-bottom-left-radius: 0px;
   border-bottom-right-radius: 0px;
 }
-


### PR DESCRIPTION
It looks like this: 

![icon](http://f.cl.ly/items/390N3J0D1Q1W0a3l1r2R/Screen%20Shot%202013-04-29%20at%205.52.59%20PM.png)

The margin fiddling has to do with the fact that the 2x icon is 29px high while the 1x icon is 15px high, which is something we could ask @larz0 to fix for us.
