### PR TITLE
Add EWF toolbar icon after the Live Development icon

### DIFF
--- a/main.js
+++ b/main.js
@@ -571,7 +571,7 @@ define(function (require, exports, module) {
 
         // set up toolbar icon
         $toolbarIcon = $(Mustache.render(ewfToolbarHtml, Strings));
-        $("#main-toolbar .buttons").append($toolbarIcon);
+        $toolbarIcon.insertAfter("#toolbar-go-live");
         
         // begin as though we are offline, but don't add any online listeners
         handleOffline(false);


### PR DESCRIPTION
Add the EWF toolbar icon after the Live Development icon instead of at the end of the list of buttons. In particular, this should sandwich the EWF icon after Live Development and before the Install Extension and Update Notification buttons.
