### PR TITLE
Fix browse dialog button focus

### DIFF
--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -76,6 +76,13 @@
 .edge-web-fonts .ewf-picker button.selected {
   background: #bdbdbd;
 }
+.edge-web-fonts .ewf-picker button:focus {
+    outline-style: none;
+    background-color: #ccc;
+}
+.edge-web-fonts .ewf-picker button.selected:focus {
+  background: #aaa;
+}
 .edge-web-fonts .ewf-picker .ewf-button {
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.48) inset;
   border: 1px solid #a6a8a8;


### PR DESCRIPTION
Removes the button focus outline in the Browse dialog, which is broken as described in issue #39, in favor of a subtly darker background color. It looks like this: 

![focus](http://f.cl.ly/items/42183r442J27472c1L0c/Screen%20Shot%202013-05-08%20at%2011.23.58%20AM.png)

(The third "M" button is highlighted above.)
