### PR TITLE
LESS support

### DIFF
--- a/cssModeSupport.js
+++ b/cssModeSupport.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    function isFontFamilyToken(t) {
+        return t.string.toLowerCase() === "font-family" &&
+            (t.className === "property" || t.className === "property error");
+                    
+    }
+    
+    function isFontNameToken(t) {
+        return t.className === "variable-2" || t.className === "string-2";
+    }
+    
+    function isFontNameStringToken(t) {
+        return t.className === "string";
+    }
+    
+    function inRuleBody(t) {
+        var stateStack = t.state.stack || t.state.localState.stack;
+        
+        return t.className !== "property" &&
+            t.className !== "property error" &&
+            stateStack.length > 0 &&
+            stateStack[stateStack.length - 1] === "propertyValue";
+    }
+    
+    exports.isFontFamilyToken = isFontFamilyToken;
+    exports.isFontNameToken = isFontNameToken;
+    exports.isFontNameStringToken = isFontNameStringToken;
+    exports.inRuleBody = inRuleBody;
+});

--- a/fontParser.js
+++ b/fontParser.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
  *  
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"), 
@@ -27,11 +27,15 @@
 
 define(function (require, exports, module) {
     "use strict";
-    
+
     var EditorManager = brackets.getModule("editor/EditorManager");
     var webfont = require("webfont");
     
-    function parseCurrentEditor(assumeCursorInvalid) {
+    function FontParser(modeSupport) {
+        this.mode = modeSupport;
+    }
+    
+    FontParser.prototype.parseCurrentEditor = function (assumeCursorInvalid) {
         var editor = EditorManager.getFocusedEditor() || EditorManager.getCurrentFullEditor();
         var cm = editor._codeMirror;
         var cursor = {ch: 0, line: 0}, t;
@@ -49,15 +53,15 @@ define(function (require, exports, module) {
                 cursor.ch = 0;
             } else {
                 // A new token!
-                if (!isParsingFontList &&
-                        (t.className === "property" || t.className === "property error") &&
-                        t.string.toLowerCase() === "font-family") {
+                if (!isParsingFontList && this.mode.isFontFamilyToken(t)) {
                     isParsingFontList = true;
                     fontListStartLine = cursor.line;
                 } else if (isParsingFontList) {
                     if (t.string === ";" || t.string === "}") {
                         isParsingFontList = false;
-                    } else if (assumeCursorInvalid && fontListStartLine === userCursor.line && fontListStartLine !== cursor.line) {
+                    } else if (assumeCursorInvalid &&
+                                fontListStartLine === userCursor.line &&
+                                fontListStartLine !== cursor.line) {
                         // If we're trying to autocomplete, assume the line the user's cursor is on might
                         // be incomplete (because s/he might be in the middle of typing). In that case,
                         // we want to assume the font list ends at the first newline (in case they
@@ -68,9 +72,9 @@ define(function (require, exports, module) {
                         // The if statement above makes it so that we don't add the font surrounding
                         // the current cursor position to the autocompletion list (but we do for the 
                         // <script> tag generation, because assumeCursorInvalid is false in that case).
-                        if (t.className === "variable-2" || t.className === "string-2") {
+                        if (this.mode.isFontNameToken(t)) {
                             fonts.push(t.string);
-                        } else if (t.className === "string") {
+                        } else if (this.mode.isFontNameStringToken(t)) {
                             // string token types still have quotes around them, so strip first/last char
                             fonts.push(t.string.substring(1, t.string.length - 1));
                         }
@@ -82,13 +86,11 @@ define(function (require, exports, module) {
         }
         
         return webfont.lowerSortUniqStringArray(fonts);
-    }
+    };
     
-    function getFontTokenAtCursor(editor, cursor) {
+    FontParser.prototype.getFontTokenAtCursor = function (editor, cursor) {
         var cm = editor._codeMirror;
         var currentToken = cm.getTokenAt(cursor);
-        var stateStack = currentToken.state.stack? currentToken.state.stack: 
-                                                   currentToken.state.localState.stack;
         var t, c;
         var result = null;
         
@@ -96,9 +98,7 @@ define(function (require, exports, module) {
         // If we're in a rule, then "rule" will be on the top of the parse stack. All
         // rules start with a "variable" token, then a ":", then values. We only want
         // autocomplete if we're somewhere after the ":"
-        if (currentToken.className !== "property" && currentToken.className !== "property error" &&
-                stateStack.length > 0 &&
-                stateStack[stateStack.length - 1] === "propertyValue") {
+        if (this.mode.inRuleBody(currentToken)) {
             
             // We're in a rule body. Step backwards until we find the most recent 
             // "variable" or are no longer in a rule (the latter, stepping out of the rule, 
@@ -106,9 +106,7 @@ define(function (require, exports, module) {
             // rule or not.
             t = currentToken;
             c = {ch: cursor.start, line: cursor.line};
-            while (t.className !== "property" && t.className !== "property error" &&
-                    stateStack.length > 0 &&
-                    stateStack[stateStack.length - 1] === "propertyValue") {
+            while (this.mode.inRuleBody(t)) {
                 c.ch = t.start - 1;
                 if (c.ch < 0) {
                     // need to go up a line
@@ -122,13 +120,12 @@ define(function (require, exports, module) {
                 t = cm.getTokenAt(c);
             }
             
-            if ((t.className === "property" || t.className === "property error") && t.string.toLowerCase() === "font-family") {
+            if (this.mode.isFontFamilyToken(t)) {
                 result = currentToken;
             }
         }
         return result;
-    }
+    };
     
-    exports.parseCurrentEditor = parseCurrentEditor;
-    exports.getFontTokenAtCursor = getFontTokenAtCursor;
+    module.exports = FontParser;
 });

--- a/lessModeSupport.js
+++ b/lessModeSupport.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    function isFontFamilyToken(t) {
+        return t.string.toLowerCase() === "font-family" &&
+            (t.className === "variable" || t.className === "variable error");
+                        
+    }
+    
+    function isFontNameToken(t) {
+        return t.className === null &&
+            t.string.trim().length > 0 &&
+            t.string.indexOf(",") === -1 &&
+            t.string.indexOf(":") === -1;
+    }
+    
+    function isFontNameStringToken(t) {
+        return t.className === "string";
+    }
+    
+    function inRuleBody(t) {
+        var stateStack = t.state.stack || t.state.localState.stack;
+        
+        return t.className !== "variable" &&
+            t.className !== "variable error" &&
+            stateStack.length > 0 &&
+            stateStack[stateStack.length - 1] === "rule";
+    }
+    
+    exports.isFontFamilyToken = isFontFamilyToken;
+    exports.isFontNameToken = isFontNameToken;
+    exports.isFontNameStringToken = isFontNameStringToken;
+    exports.inRuleBody = inRuleBody;
+});

--- a/main.js
+++ b/main.js
@@ -30,7 +30,9 @@ define(function (require, exports, module) {
     
     // Modules
     var webfont                 = require("webfont"),
-        parser                  = require("cssFontParser"),
+        FontParser              = require("fontParser"),
+        cssModeSupport          = require("cssModeSupport"),
+        lessModeSupport         = require("lessModeSupport"),
         ewfBrowseDialogHtml     = require("text!htmlContent/ewf-browse-dialog.html"),
         ewfIncludeDialogHtml    = require("text!htmlContent/ewf-include-dialog.html"),
         ewfHowtoDialogHtml      = require("text!htmlContent/ewf-howto-dialog.html"),
@@ -65,6 +67,10 @@ define(function (require, exports, module) {
     var COMMAND_GENERATE_INCLUDE = "edgewebfonts.generateinclude";
     var PREFERENCES_CLIENT_ID = "com.adobe.edgewebfonts";
     var PREFERENCES_FONT_HISTORY_KEY = "ewf-font-history";
+
+    // Font parsers    
+    var cssParser   = new FontParser(cssModeSupport),
+        lessParser  = new FontParser(lessModeSupport);
     
     // Local variables
     var lastFontSelected = null;
@@ -75,12 +81,46 @@ define(function (require, exports, module) {
     var fontnameStartRegExp = /[\w"']/;
     var scriptCache = {};
     
-    function _documentIsCSS(doc) {
-        return doc && doc.getLanguage().getName() === "CSS";
+    function _supportedLanguage(language) {
+        var name = language.getName();
+            
+        return (name === "CSS" || name === "LESS");
+    }
+    
+    function _supportedDocument(doc) {
+        return doc && _supportedLanguage(doc.getLanguage());
     }
 
-    function _contextIsCSS(editor) {
-        return editor && editor.getLanguageForSelection().getName() === "CSS";
+    function _supportedContext(editor) {
+        return editor && _supportedLanguage(editor.getLanguageForSelection());
+    }
+    
+    function _getParserForContext(editor) {
+        var language    = editor.getLanguageForSelection(),
+            name        = language.getName();
+        
+        switch (name) {
+        case "CSS":
+            return cssParser;
+        case "LESS":
+            return lessParser;
+        default:
+            throw new Error("Unsupported language: " + name);
+        }
+    }
+    
+    function _getModeSupportForContext(editor) {
+        var language    = editor.getLanguageForSelection(),
+            name        = language.getName();
+        
+        switch (name) {
+        case "CSS":
+            return cssModeSupport;
+        case "LESS":
+            return lessModeSupport;
+        default:
+            throw new Error("Unsupported language: " + name);
+        }
     }
     
     /** Adds an option to browse EWF to the bottom of the code hint list
@@ -154,22 +194,24 @@ define(function (require, exports, module) {
     }
     
     function _insertFontCompletionAtCursor(completion, editor, cursor) {
-        var token;
+        var modeSupport, parser, token;
         var actualCompletion = completion;
         var stringChar = "\"";
         
-        if (_contextIsCSS(editor)) { // on the off-chance we changed documents, don't change anything
+        if (_supportedContext(editor)) { // on the off-chance we changed documents, don't change anything
+            modeSupport = _getModeSupportForContext(editor);
+            parser = _getParserForContext(editor);
             token = parser.getFontTokenAtCursor(editor, cursor);
             if (token) {
                 // get the correct string character if there is already one in use
-                if (token.className === "string") {
+                if (modeSupport.isFontNameStringToken(token)) {
                     stringChar = token.string.substring(0, 1);
                 }
 
                 // wrap the completion in string character if either 
                 //  a.) we're inserting into a string, or 
                 //  b.) the slug contains a space
-                if (token.className === "string" || whitespaceRegExp.test(actualCompletion)) {
+                if (modeSupport.isFontNameStringToken(token) || whitespaceRegExp.test(actualCompletion)) {
                     actualCompletion = stringChar + actualCompletion + stringChar;
                 }
 
@@ -178,7 +220,7 @@ define(function (require, exports, module) {
                 // line is a string. So, we want to stop at the first occurrence of a comma or 
                 // semi-colon.
                 var endChar = token.end;
-                if (token.className === "string") {
+                if (modeSupport.isFontNameStringToken(token)) {
                     // Find the *first* comma or semi
                     var match = commaSemiRegExp.exec(token.string);
                     if (match) {
@@ -191,7 +233,8 @@ define(function (require, exports, module) {
                 // directly to replace the range instead of using the Document, as we should. The
                 // reason is due to a flaw in our current document synchronization architecture when
                 // inline editors are open.
-                if (token.className === "string" || token.className === "variable-2" || token.className === "string-2") { // replace
+                if (modeSupport.isFontNameStringToken(token) ||
+                        modeSupport.isFontNameToken(token)) { // replace
                     editor._codeMirror.replaceRange(actualCompletion,
                                                  {line: cursor.line, ch: token.start},
                                                  {line: cursor.line, ch: endChar});
@@ -240,8 +283,11 @@ define(function (require, exports, module) {
      * whether it is appropriate to do so.
      */
     FontHints.prototype.hasHints = function (editor, implicitChar) {
+        var parser;
+        
         this.editor = editor;
-        if (_contextIsCSS(editor)) {
+        if (_supportedContext(editor)) {
+            parser = _getParserForContext(editor);
             if (!implicitChar) {
                 if (parser.getFontTokenAtCursor(editor, editor.getCursorPos())) {
                     return true;
@@ -280,12 +326,16 @@ define(function (require, exports, module) {
             cursor = editor.getCursorPos(),
             query,
             lowerCaseQuery,
+            modeSupport,
+            parser,
             token;
         
-        if (_contextIsCSS(editor)) {
+        if (_supportedContext(editor)) {
+            modeSupport = _getModeSupportForContext(editor);
+            parser = _getParserForContext(editor);
             token = parser.getFontTokenAtCursor(editor, cursor);
             if (token) {
-                if (token.className === "string") { // is wrapped in quotes        
+                if (modeSupport.isFontNameStringToken(token)) { // is wrapped in quotes        
                     if (token.start < cursor.ch) { // actually in the text
                         query = token.string.substring(1, cursor.ch - token.start);
                         if (token.end === cursor.ch) { // at the end, so need to clip off closing quote
@@ -294,7 +344,7 @@ define(function (require, exports, module) {
                     } else { // not in the text
                         query = "";
                     }
-                } else if (token.className === "variable-2" || token.className === "string-2") { // is not wrapped in quotes
+                } else if (modeSupport.isFontNameToken(token)) { // is not wrapped in quotes
                     query = token.string.substring(0, cursor.ch - token.start);
                 } else { // after a ":", a space, or a ","
                     query = "";
@@ -403,6 +453,8 @@ define(function (require, exports, module) {
          *  configurator UI that lets users specify which variants and subsets they want
          */
         function _handleGenerateInclude() {
+            var editor = EditorManager.getFocusedEditor() || EditorManager.getCurrentFullEditor();
+            var parser = _getParserForContext(editor);
             var fonts = parser.parseCurrentEditor(false);
             var fontFamilies = [], allFvds = [];
             var i, j, f;
@@ -430,7 +482,7 @@ define(function (require, exports, module) {
         
         // install autocomplete handler
         var fontHints = new FontHints();
-        CodeHintManager.registerHintProvider(fontHints, ["css"], 1);
+        CodeHintManager.registerHintProvider(fontHints, ["css", "less"], 1);
         
         // load blank font
         ExtensionUtils.loadStyleSheet(module, "styles/adobe-blank.css");
@@ -478,7 +530,7 @@ define(function (require, exports, module) {
         function _handleToolbarClick() {
             var doc = DocumentManager.getCurrentDocument();
 
-            if (!doc || !_documentIsCSS(doc)) {
+            if (!doc || !_supportedDocument(doc)) {
                 _showHowtoDialog();
             } else {
                 CommandManager.execute(COMMAND_GENERATE_INCLUDE);
@@ -488,7 +540,7 @@ define(function (require, exports, module) {
         function _handleDocumentChange() {
             var doc = DocumentManager.getCurrentDocument();
             // doc will be null if there's no active document (user closed all docs)
-            if (doc && _documentIsCSS(doc)) {
+            if (doc && _supportedDocument(doc)) {
                 $toolbarIcon.addClass("active");
             } else {
                 $toolbarIcon.removeClass("active");

--- a/test/style.less
+++ b/test/style.less
@@ -1,0 +1,64 @@
+.modal-bar {
+    text-align: left;
+    font-family: @fontstack-sans-serif, "andale mono3", helvetica3, foobar3;
+    font-size: 13px;
+
+    /* the best heading */
+    h1 {
+        font-family: "alice2", monospace2, ;
+        font-weight: normal;
+    }
+    h2 {
+        font-family: "droid-sans2", /* comment */ "advent-pro2", monospace2;
+        font-weight: normal;
+    }
+    h3 {
+        font-family: Abril-fatFace2, verdana2, monospace2, ;
+        font-style: normal;
+    }
+    p {
+        font-family: adamina2, monospace2;
+        font-style: normal;
+    }
+    
+    body.in-browser & {
+        // Separator line between us and the HTML menu/titlebar above
+        border-top: 1px solid darken(@background-color-3, @bc-color-step-size);
+        
+        /* the best heading */
+        h1 {
+            font-family: "alice1", monospace1, ;
+            font-weight: normal;
+        }
+        h2 {
+            font-family: "droid-sans1", /* comment */ "advent-pro1", monospace1;
+            font-weight: normal;
+        }
+        h3 {
+            font-family: Abril-fatFace1, verdana1, monospace1;
+            font-style: normal;
+        }
+        p {
+            font-family: adamina1, monospace1;
+            font-style: normal;
+        }
+    }
+}
+
+/* the best heading */
+h1 {
+    font-family: "alice0", monospace0, ;
+    font-weight: normal;
+}
+h2 {
+    font-family: "droid-sans0", /* comment */ "advent-pro0", monospace0;
+    font-weight: normal;
+}
+h3 {
+    font-family: Abril-fatFace0, verdana0, monospace0;
+    font-style: normal;
+}
+p {
+    font-family: adamina0, monospace0;
+    font-style: normal;
+}


### PR DESCRIPTION
Enable web font hinting in LESS files. 

This generalizes the previous cssFontParser into a FontParser class parametrized by a modeSupport object that can distinguish between CodeMirror tokens that represent font-name values, font-family properties, and inclusion in rule bodies.

SASS support yet to come...
