### PR TITLE
Insert web font on double click

### DIFF
--- a/main.js
+++ b/main.js
@@ -435,13 +435,26 @@ define(function (require, exports, module) {
             var editor = EditorManager.getFocusedEditor();
             var cursor = editor._codeMirror.getCursor();
             lastFontSelected = null;
-            Dialogs.showModalDialog("edge-web-fonts-browse-dialog").done(function (id) {
-                if (id === Dialogs.DIALOG_BTN_OK && lastFontSelected) {
+
+            function handleFontChosen() {
+                if (lastFontSelected) {
                     _insertFontCompletionAtCursor(lastFontSelected, editor, cursor);
                 }
                 editor.focus();
+                $(webfont).off("ewfFontChosen");
+            }
+            
+            Dialogs.showModalDialog("edge-web-fonts-browse-dialog").done(function (id) {
+                if (id === Dialogs.DIALOG_BTN_OK) {
+                    handleFontChosen();
+                }
             });
             webfont.renderPicker($('.instance .edge-web-fonts-browse-dialog-body')[0]);
+            
+            $(webfont).on("ewfFontChosen", function () {
+                handleFontChosen();
+                Dialogs.cancelModalDialogIfOpen("edge-web-fonts-browse-dialog");
+            });
         }
         
         /** Determines what font slugs are in the CSS file and generates the appropriate

--- a/webfont.js
+++ b/webfont.js
@@ -185,11 +185,17 @@ define(function (require, exports, module) {
                 $(exports).triggerHandler("ewfFontSelected", d.attributes["data-slug"].value);
             }
         }
+        
+        function fontDoubleClickHandler(event) {
+            fontClickHandler(event);
+            $(exports).triggerHandler("ewfFontChosen");
+        }
 
         if ($results) {
             $results.empty();
             $results.html(Mustache.render(resultsHtml, {Strings: Strings, families: families}));
-            $(".ewf-font").click(fontClickHandler);
+            $(".ewf-font").click(fontClickHandler)
+                .dblclick(fontDoubleClickHandler);
         }
     }
     


### PR DESCRIPTION
With this pull request, double-clicking a font tile in the EWF picker dismisses the dialog and inserts it.

This one goes out to @njx! (Which is to say that it addresses issue #9.)
