### PR TITLE
Focus the search field by default in the picker dialog

### DIFF
--- a/htmlContent/ewf-picker.html
+++ b/htmlContent/ewf-picker.html
@@ -1,7 +1,7 @@
 <div class="ewf-picker">
     <div class="ewf-tabs">
         <p>{{Strings.BROWSE_FONTS_INSTRUCTIONS}}</p>
-        <input type="text" placeholder="{{Strings.SEARCH_PLACEHOLDER}}" class="ewf-search-fonts">
+        <input type="text" placeholder="{{Strings.SEARCH_PLACEHOLDER}}" class="ewf-search-fonts" autofocus="autofocus">
         <div class="ewf-side-bar">
             <ul class="recommended-uses">
                 {{#localizedRecommendations}}


### PR DESCRIPTION
It looks like this now: 

![focus](http://f.cl.ly/items/0Z1z362L2g1P452x0z1O/Screen%20Shot%202013-05-17%20at%201.18.39%20PM.png)

Currently, nothing is focused when the dialog is opened.
