### PR TITLE
Remove superfluous background-color property in definition of ewf-picker class

### DIFF
--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -40,7 +40,6 @@
 .edge-web-fonts .ewf-picker {
   position: static;
   width: 100%;
-  background-color: white;
 }
 .edge-web-fonts .ewf-picker .ewf-side-bar {
   float: left;


### PR DESCRIPTION
Addresses issue #111. With the patch it looks like this: 

![111](http://f.cl.ly/items/002b1U3l1F0w3q1y0G1U/Screen%20Shot%202013-05-20%20at%2010.54.27%20AM.png)

(We may need to generally rethink the colors in this dialog, in particular the classification buttons on the left.)
