### PR TITLE
Fix the instructions icon

### DIFF
--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -289,11 +289,12 @@
   margin-bottom: 0px;
 }
 .edge-web-fonts-howto-dialog .instructions-icon {
-    background: no-repeat -webkit-image-set(url("../img/webfonts_icon.png") 1x, url("../img/webfonts_icon@2x.png") 2x);
+    background: no-repeat url("../img/toolbar.svg");
+    background-position: -40px 0px;
     display: inline-block;
-    width: 21px;
-    height: 15px;
-    margin-top: -2px;
+    width: 20px;
+    height: 20px;
+    margin-bottom: -4px;
 }
 
 .edge-web-fonts-howto-diagram {


### PR DESCRIPTION
Recent changes to the toolbar icon broke the picture in the instructions icon, as described in #115. This pull request fixes that. Now it looks like this: 

![115](http://f.cl.ly/items/0A3N0t3l433m0l1A2i1D/Screen%20Shot%202013-05-21%20at%2010.33.13%20AM.png)

@ryanstewart Are you OK with: 
1. use of the blue, active icon; and
2. the fact that the T is inverted? 

These both seem fine to me. But, if you don't think so, we'll need to get @larz0 to make us an icon without transparency. 
