### PR TITLE
Vertically align the modal dialog close buttons within the header.

### DIFF
--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -21,6 +21,13 @@
  * 
  */
 
+.edge-web-fonts-browse-dialog .modal-header .close,
+.edge-web-fonts-include-dialog .modal-header .close,
+.edge-web-fonts-howto-dialog .modal-header .close {
+    margin-top: 0px;
+    line-height: 40px;
+}
+
 .edge-web-fonts-browse-dialog .modal-body,
 .edge-web-fonts-browse-dialog .modal-header {
   width: 505px;


### PR DESCRIPTION
Before: 
![before](http://f.cl.ly/items/1B0i2P051e2r3f2J0C2k/Screen%20Shot%202013-05-21%20at%2012.38.10%20PM.png)

After:
![after](http://f.cl.ly/items/0Q2X0o3e2M291g0u3E0m/Screen%20Shot%202013-05-21%20at%2012.53.20%20PM.png)

(The `line-height` of the `<h1>` in the header is set to 40 pixels, and there is a default non-zero `top-margin` defined elsewhere.)
