### PR TITLE
Improve search results for the empty query

### DIFF
--- a/webfont.js
+++ b/webfont.js
@@ -229,8 +229,16 @@ define(function (require, exports, module) {
         function searchExecutor(query) {
             var fonts = searchByName(query);
             // clear any previously selected class
-            $('.ewf-tabs button').removeClass("selected");
-            _displayResults(fonts);
+            $('.ewf-results button').removeClass("selected");
+            
+            if (fonts.length > 0) {
+                _displayResults(fonts);
+            } else {
+                var $button = $(".ewf-side-bar button.selected"),
+                    classification = $button.attr("data-classification");
+                fonts = fontsByClass[classification];
+                _displayResults(fonts);
+            }
         }
         
         function searchHandler(event) {


### PR DESCRIPTION
There is a bug/feature in the EWF search dialog in which the empty search query will return no results. This was actually done intentionally by @joelrbrandt to work around a Chrome bug that can cause a crash if too many file descriptors are opened at once. This can happen if we try to show result tiles for all the fonts at once, which is what one might otherwise wish to do in this case. The recent change that focused the search dialog box by default exacerbated this problem for complicated reasons that I won't go into here.

ANYWAY, this pull request changes the way search results are returned for the empty query. It now shows just those results that match the chosen font classification as indicated by the selected button on the left side. (This is also how the search results have historically been initialized.)
