### PR TITLE
Search dialog keyboard navigation

### DIFF
--- a/htmlContent/ewf-picker.html
+++ b/htmlContent/ewf-picker.html
@@ -1,12 +1,12 @@
 <div class="ewf-picker">
     <div class="ewf-tabs">
         <p>{{Strings.BROWSE_FONTS_INSTRUCTIONS}}</p>
-        <input type="text" placeholder="{{Strings.SEARCH_PLACEHOLDER}}" class="ewf-search-fonts" autofocus="autofocus">
+        <input type="text" placeholder="{{Strings.SEARCH_PLACEHOLDER}}" class="ewf-search-fonts" autofocus="autofocus" tabindex="0">
         <div class="ewf-side-bar">
             <ul class="recommended-uses">
                 {{#localizedRecommendations}}
                     <li>
-                        <button title="{{localizedName}}" data-classification="{{className}}" class="ewf-classification-button">
+                        <button title="{{localizedName}}" data-classification="{{className}}" class="ewf-classification-button" tabindex="-1">
                             <div class="ewf-icon {{className}}"></div>
                         </button>
                     </li>
@@ -15,7 +15,7 @@
             <ul class="font-classifications">
                 {{#localizedClassifications}}
                     <li>
-                        <button title="{{localizedName}}" data-classification="{{className}}" class="ewf-classification-button">
+                        <button title="{{localizedName}}" data-classification="{{className}}" class="ewf-classification-button" tabindex="-1">
                             <div class="ewf-icon {{className}}"></div>
                         </button>
                     </li>

--- a/htmlContent/ewf-results.html
+++ b/htmlContent/ewf-results.html
@@ -1,8 +1,7 @@
 {{#families}}
-<div class="ewf-font" data-slug="{{slug}}" style="background-image: url({{thumbnails.edge}})">
+<button class="ewf-font" data-slug="{{slug}}" style="background-image: url({{thumbnails.edge}})" tabindex="{{index}}">
     <div class="ewf-font-details">
         <label>{{name}}</label>
     </div>
-</div>
+</button>
 {{/families}}
-

--- a/main.js
+++ b/main.js
@@ -440,7 +440,7 @@ define(function (require, exports, module) {
                     handleFontChosen();
                 }
             });
-            webfont.renderPicker($('.instance .edge-web-fonts-browse-dialog-body')[0]);
+            webfont.renderPicker($('.edge-web-fonts-browse-dialog.instance'));
             
             $(webfont).on("ewfFontChosen", function () {
                 handleFontChosen();

--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -77,18 +77,18 @@
 .edge-web-fonts .ewf-picker button {
   padding: 0;
 }
-.edge-web-fonts .ewf-picker button:hover {
+.edge-web-fonts .ewf-tabs button:hover {
   background: #dce1e4;
   background-position: 0 -30px;
 }
-.edge-web-fonts .ewf-picker button.selected {
+.edge-web-fonts .ewf-tabs button.selected {
   background: #bdbdbd;
 }
-.edge-web-fonts .ewf-picker button:focus {
+.edge-web-fonts .ewf-tabs button:focus {
     outline-style: none;
     background-color: #ccc;
 }
-.edge-web-fonts .ewf-picker button.selected:focus {
+.edge-web-fonts .ewf-tabs button.selected:focus {
   background: #aaa;
 }
 .edge-web-fonts .ewf-picker .ewf-button {
@@ -171,7 +171,9 @@
   background-position: 50% -20px;
   cursor: pointer;
 }
+.edge-web-fonts .ewf-picker .ewf-font:focus,
 .edge-web-fonts .ewf-picker .ewf-font.selected {
+  outline: none;
   border: 1px solid #F18900;
 }
 .edge-web-fonts .ewf-picker .ewf-font-details {

--- a/webfont.js
+++ b/webfont.js
@@ -180,6 +180,7 @@ define(function (require, exports, module) {
             }
             
             if (d) {
+                d.focus();
                 $(".ewf-font.selected").removeClass("selected");
                 $(d).addClass("selected");
                 $(exports).triggerHandler("ewfFontSelected", d.attributes["data-slug"].value);
@@ -192,14 +193,21 @@ define(function (require, exports, module) {
         }
 
         if ($results) {
+            families.forEach(function (elem, index) {
+                // tabindex starts at one
+                elem.index = index + 1;
+            });
+            
             $results.empty();
             $results.html(Mustache.render(resultsHtml, {Strings: Strings, families: families}));
             $(".ewf-font").click(fontClickHandler)
+                .focus(fontClickHandler)
                 .dblclick(fontDoubleClickHandler);
         }
     }
     
-    function renderPicker(domElement) {
+    function renderPicker($dlg) {
+        var domElement = $dlg.find(".edge-web-fonts-browse-dialog-body")[0];
         var localizedClassifications = [];
         var localizedRecommendations = [];
         var i;
@@ -252,10 +260,20 @@ define(function (require, exports, module) {
         for (i = 0; i < fontRecommendations.length; i++) {
             localizedRecommendations.push({className: fontRecommendations[i], localizedName: Strings[fontRecommendations[i]]});
         }
-
         
         $picker = $(Mustache.render(pickerHtml, {Strings: Strings, localizedClassifications: localizedClassifications, localizedRecommendations: localizedRecommendations}));
         $(domElement).append($picker);
+        
+        // set the dialog's OK button to have a very large tabindex so that it
+        // will only gain focus after tabbing past the last font result
+        $dlg.find(".dialog-button").attr("tabindex", 99999);
+        
+        // prevent tabbing in front of the search input
+        $dlg.find(".ewf-search-fonts").on("keydown", function (event) {
+            if (event.shiftKey && event.keyCode === 9) {
+                event.preventDefault();
+            }
+        });
 
         $(".ewf-tabs button", $picker).click(classificationClickHandler);
         


### PR DESCRIPTION
This pull request adds keyboard navigation by pressing tab or shift-tab to select font tiles. It is then possible to insert the selected font and dismiss the dialog by pressing enter. This is almost all accomplished by just setting the HTML `tabindex` attribute properly.

Addresses issue #36.
