### PR TITLE
Always give editor focus when dismissing search dialog

### DIFF
--- a/main.js
+++ b/main.js
@@ -430,8 +430,7 @@ define(function (require, exports, module) {
             function handleFontChosen() {
                 if (lastFontSelected) {
                     _insertFontCompletionAtCursor(lastFontSelected, editor, cursor);
-                }
-                editor.focus();
+                }                
                 $(webfont).off("ewfFontChosen");
             }
             
@@ -439,12 +438,14 @@ define(function (require, exports, module) {
                 if (id === Dialogs.DIALOG_BTN_OK) {
                     handleFontChosen();
                 }
+                editor.focus();
             });
             webfont.renderPicker($('.instance .edge-web-fonts-browse-dialog-body')[0]);
             
             $(webfont).on("ewfFontChosen", function () {
-                handleFontChosen();
                 Dialogs.cancelModalDialogIfOpen("edge-web-fonts-browse-dialog");
+                handleFontChosen();
+                editor.focus();
             });
         }
         


### PR DESCRIPTION
This fixes a small bug in which the editor would not receive focus when dismissing the search dialog with the escape key. 
