### PR TITLE
Fix LESS font-name identification

### DIFF
--- a/lessModeSupport.js
+++ b/lessModeSupport.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
     }
     
     function isFontNameToken(t) {
-        return t.className === null &&
+        return (t.className === null || t.className === "tag") &&
             t.string.trim().length > 0 &&
             t.string.indexOf(",") === -1 &&
             t.string.indexOf(":") === -1;


### PR DESCRIPTION
Fixes a bug in LESS files where no font name would be found in contexts without a trailing delimiter. For example, after typing:

```
font-family: 
```

no intermediate font names are be found, and so the hint list is never filtered. The problem doesn't appear if there is a trailing semicolon or comma.

This is a high priority bug for Edge Code. 

CC @bchintx, @pthiess @ryanstewart 
