### PR TITLE
Miscellaneous dialog fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -216,7 +216,8 @@ define(function (require, exports, module) {
     }
     
     function _showHowtoDialog() {
-        Dialogs.showModalDialogUsingTemplate(ewfHowtoDialogTemplate);
+        var dlg = Dialogs.showModalDialogUsingTemplate(ewfHowtoDialogTemplate);
+        dlg.getElement().find(".close").on("click", dlg.close.bind(dlg));
         
         $(".edge-web-fonts-howto-diagram").css("background-image", "-webkit-image-set(url('" + howtoDiagramURL + "') 1x, url('" + howtoDiagramHiDPIURL + "') 2x)");
     }
@@ -441,12 +442,15 @@ define(function (require, exports, module) {
                 $(webfont).off("ewfFontChosen");
             }
             
-            var dlg = Dialogs.showModalDialogUsingTemplate(ewfBrowseDialogTemplate).done(function (id) {
+            var dlg = Dialogs.showModalDialogUsingTemplate(ewfBrowseDialogTemplate);
+            dlg.done(function (id) {
                 if (id === Dialogs.DIALOG_BTN_OK) {
                     handleFontChosen();
                 }
                 editor.focus();
             });
+            dlg.getElement().find(".close").on("click", dlg.close.bind(dlg));
+            
             webfont.renderPicker($('.edge-web-fonts-browse-dialog.instance'));
             
             $(webfont).on("ewfFontChosen", function () {
@@ -487,7 +491,8 @@ define(function (require, exports, module) {
                 _showHowtoDialog();
             } else {
                 includeString = webfont.createInclude(fontFamilies);
-                Dialogs.showModalDialogUsingTemplate(ewfIncludeDialogTemplate);
+                var dlg = Dialogs.showModalDialogUsingTemplate(ewfIncludeDialogTemplate);
+                dlg.getElement().find(".close").on("click", dlg.close.bind(dlg));
                 $('.instance .ewf-include-string').html(StringUtils.htmlEscape(includeString)).focus().select();
             }
         }

--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -24,8 +24,13 @@
 .edge-web-fonts-browse-dialog .modal-header .close,
 .edge-web-fonts-include-dialog .modal-header .close,
 .edge-web-fonts-howto-dialog .modal-header .close {
-    margin-top: 0px;
-    line-height: 40px;
+    line-height: 50px;
+}
+
+.edge-web-fonts-browse-dialog .modal-header h1.dialog-title,
+.edge-web-fonts-include-dialog .modal-header h1.dialog-title,
+.edge-web-fonts-howto-dialog .modal-header h1.dialog-title {
+    margin: 5px 0;
 }
 
 .edge-web-fonts-browse-dialog .modal-body,
@@ -34,6 +39,7 @@
 }
 .edge-web-fonts-browse-dialog .modal-body {
   padding: 15px 0 15px 15px;
+  overflow: hidden;
 }
 .edge-web-fonts div {
   -webkit-box-sizing: border-box;
@@ -150,7 +156,7 @@
 }
 .edge-web-fonts .ewf-picker .ewf-results {
   position: absolute;
-  bottom: 63px;
+  bottom: 0px;
   left: 50px;
   width: 485px;
   height: 335px;
@@ -278,6 +284,10 @@
   float: left;
   top: 7px;
   left: 3px;
+}
+.edge-web-fonts-include-dialog code {
+  color: #454545;
+  font-size: smaller;
 }
 .edge-web-fonts-include-dialog textarea {
   width: 550px;

--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -24,13 +24,8 @@
 .edge-web-fonts-browse-dialog .modal-header .close,
 .edge-web-fonts-include-dialog .modal-header .close,
 .edge-web-fonts-howto-dialog .modal-header .close {
-    line-height: 50px;
-}
-
-.edge-web-fonts-browse-dialog .modal-header h1.dialog-title,
-.edge-web-fonts-include-dialog .modal-header h1.dialog-title,
-.edge-web-fonts-howto-dialog .modal-header h1.dialog-title {
-    margin: 5px 0;
+    margin-top: 0px;
+    line-height: 40px;
 }
 
 .edge-web-fonts-browse-dialog .modal-body,


### PR DESCRIPTION
This fixes a handful of problems with the EWF dialogs that arose during the Brackets Sprint-26 jQuery/LESS/Bootstrap/modal-dialog upgrade. This patch fixes in particular:  
1. ~~the vertical alignment of the modal header titles and close buttons;~~
2. the font size and color of the code block in the insert dialog;
3. an issue where the entire modal body of the picker dialog was scrollable inside the dialog;
4. the alignment of the font tiles within the picker dialog; 
5. various dialog dismissal bugs, chief of which prevented close icon clicks from dismissing the dialog.
