### PR TITLE
[REVIEW ONLY] Append comma when inserting before another font token

### DIFF
--- a/main.js
+++ b/main.js
@@ -185,7 +185,33 @@ define(function (require, exports, module) {
                     if (match) {
                         endChar = token.start + match.index;
                     }
-                    
+                }
+
+                var nextCursor,
+                    nextLine;
+                
+                if (token.end === line.length) {
+                    nextCursor = { line: cursor.line + 1, ch: 0 };
+                    nextLine = editor.document.getLine(nextCursor.line);
+                } else {
+                    nextCursor = { line: cursor.line, ch: token.end + 1 };
+                    nextLine = line;
+                }
+                
+                var nextToken = editor._codeMirror.getTokenAt(nextCursor);
+                while (nextToken && !nextToken.string.trim().length) {
+                    nextCursor.ch = nextToken.end + 1;
+                    if (nextCursor.ch > nextLine.length) {
+                        nextCursor.ch = 0;
+                        nextCursor.line++;
+                        nextLine = editor.document.getLine(nextCursor.line);
+                    }
+                    nextToken = editor._codeMirror.getTokenAt(nextCursor);
+                }
+                
+                if (nextToken && nextToken.string !== token.string &&
+                        !commaSemiRegExp.test(nextToken.string)) {
+                    actualCompletion += ",";
                 }
                 
                 // HACK (tracking adobe/brackets#1688): We talk to the private CodeMirror instance


### PR DESCRIPTION
This is yet another attempt at resolving #5. I'm not very confident in its correctness though, which is why this pull request is for review only. The basic strategy is to skip to the next cursor position after the current token, and then consume tokens until we either run out of tokens and get a null token or get a non-null token that is not just whitespace. If we got a non-null token and the whitespace doesn't contain a semicolon or a comma, then append a comma to the eventual completion. 

Testing very welcome.
