### PR TITLE
Fix Issue #142- "[L10N][German]: Overlocalized Edge Web Fonts page and tooltip in German OS"

### DIFF
--- a/nls/strings.js
+++ b/nls/strings.js
@@ -37,7 +37,6 @@ define(function (require, exports, module) {
     // TODO: dynamically populate the local prefix list below?
     module.exports = {
         root: true,
-        "fr": true,
-        "de": true
+        "fr": true
     };
 });


### PR DESCRIPTION
Fixed Issue #142 - "[L10N][German]: Overlocalized Edge Web Fonts page and tooltip in German OS".

Removed German ("de") from the list of supported languages.  Leave the actual translation though for future use.
