### PR TITLE
Make font insertion smarter, so that a comma is inserted after the inserted font name if necessary

### DIFF
--- a/main.js
+++ b/main.js
@@ -179,13 +179,12 @@ define(function (require, exports, module) {
                     actualCompletion = " " + actualCompletion;
                 }
                 
-                var charAfterCursor = line.charAt(token.start + 1);
+                var charAfterCursor = line.charAt(cursor.ch);
 
-                if (!whitespaceRegExp.test(charAfterCursor)
-                        && charAfterCursor !== ","
-                        && charAfterCursor !== ";"
+                if (charAfterCursor !== ","
+                        && (charAfterCursor !== ";")
                         && !(prefix === token.string && !whitespaceRegExp.test(prefix))
-                        ) {
+                ) {
                     actualCompletion = actualCompletion + ", ";
                 }
                 

--- a/main.js
+++ b/main.js
@@ -173,10 +173,20 @@ define(function (require, exports, module) {
                 var tokenIsPrefix = ((modeSupport.isFontNameToken(token) || modeSupport.isFontNameStringToken(token)) &&
                                      (actualCompletion.indexOf(prefix) === 0 || completion.indexOf(prefix) === 0));
                 
-                var charBeforeCursor = tokenIsPrefix ? line.charAt(token.start - 1) : line.charAt(token.start);
+                var charBeforeCursor = tokenIsPrefix || prefix === token.string ? line.charAt(token.start - 1) : line.charAt(token.start);
                 
-                if (!whitespaceRegExp.test(charBeforeCursor)) {
+                if (!whitespaceRegExp.test(charBeforeCursor) && !whitespaceRegExp.test(prefix)) {
                     actualCompletion = " " + actualCompletion;
+                }
+                
+                var charAfterCursor = line.charAt(token.start + 1);
+
+                if (!whitespaceRegExp.test(charAfterCursor)
+                        && charAfterCursor !== ","
+                        && charAfterCursor !== ";"
+                        && !(prefix === token.string && !whitespaceRegExp.test(prefix))
+                        ) {
+                    actualCompletion = actualCompletion + ", ";
                 }
                 
                 if (modeSupport.isFontNameStringToken(token)) {

--- a/main.js
+++ b/main.js
@@ -181,10 +181,9 @@ define(function (require, exports, module) {
                 
                 var charAfterCursor = line.charAt(cursor.ch);
 
-                if (charAfterCursor !== ","
-                        && (charAfterCursor !== ";")
-                        && !(prefix === token.string && !whitespaceRegExp.test(prefix))
-                ) {
+                if (charAfterCursor !== "," &&
+                        (charAfterCursor !== ";") &&
+                        !(prefix === token.string && !whitespaceRegExp.test(prefix))) {
                     actualCompletion = actualCompletion + ", ";
                 }
                 


### PR DESCRIPTION
fix https://github.com/adobe/brackets-edge-web-fonts/issues/5
