### PR TITLE
Fix ToU link click handling

### DIFF
--- a/nls/de/strings.js
+++ b/nls/de/strings.js
@@ -37,7 +37,7 @@ define({
     "HOWTO_INSTRUCTIONS_2"           : "Beim definieren eines font-family Attributs in einem CSS Dokument, bitte 'Web-Fonts durchsuchen' aus dem Autovervollständigungs-Dialog auswählen um die kostenlosen Web-Fonts zu durchsuchen.",
     "HOWTO_INSTRUCTIONS_3"           : "Wenn Sie fertig sind, klicken Sie auf das <div class='instructions-icon'></div> Icon oben rechts um den benötigten Einbettungscode zu generieren.",
     "HOWTO_INSTRUCTIONS_4"           : "Fügen Sie den Einbettungscode in jede HTML-Seite ein um die Schriften zu integrieren.",
-    "TERMS_OF_USE"                   : "<a class=\"clickable-link\" data-href=\"http://adobe.com/go/edgewebfonts_tou\">Edge Web Fonts Nutzungsbedingungen</a>",
+    "TERMS_OF_USE"                   : "<a class=\"clickable-link\" href=\"http://adobe.com/go/edgewebfonts_tou\">Edge Web Fonts Nutzungsbedingungen</a>",
     "SAMPLE_TEXT"                    : "Beispiel",
     
     // Font classifications

--- a/nls/fr/strings.js
+++ b/nls/fr/strings.js
@@ -40,7 +40,7 @@ define({
 	"HOWTO_INSTRUCTIONS_4": "Collez ce code d’intégration dans une page HTML afin d’inclure les polices.",
 	"HOWTO_DIAGRAM_IMAGE": "img/ewf-howto-dialog-fr.png",
 	"HOWTO_DIAGRAM_IMAGE_HIDPI": "img/ewf-howto-dialog-fr@2x.png",
-	"TERMS_OF_USE": "<a class=\"clickable-link\" data-href=\"http://adobe.com/go/edgewebfonts_tou_fr\">Conditions d’utilisation d’Edge Web Fonts</a>",
+	"TERMS_OF_USE": "<a class=\"clickable-link\" href=\"http://adobe.com/go/edgewebfonts_tou_fr\">Conditions d’utilisation d’Edge Web Fonts</a>",
 	"SAMPLE_TEXT": "Exemple",
     
     // Font classifications

--- a/nls/ja/strings.js
+++ b/nls/ja/strings.js
@@ -40,7 +40,7 @@ define({
 	"HOWTO_INSTRUCTIONS_4": "埋め込みコードを HTML ページにペーストしてフォントを追加します。",
 	"HOWTO_DIAGRAM_IMAGE": "img/ewf-howto-dialog-ja.png",
 	"HOWTO_DIAGRAM_IMAGE_HIDPI": "img/ewf-howto-dialog-ja@2x.png",
-	"TERMS_OF_USE": "<a class=\"clickable-link\" data-href=\"http://adobe.com/go/edgewebfonts_tou_jp\">Edge Web Fonts 利用条件</a>",
+	"TERMS_OF_USE": "<a class=\"clickable-link\" href=\"http://adobe.com/go/edgewebfonts_tou_jp\">Edge Web Fonts 利用条件</a>",
 	"SAMPLE_TEXT": "サンプル",
     
     // Font classifications

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -40,7 +40,7 @@ define({
     "HOWTO_INSTRUCTIONS_4"           : "Paste the embed code into any HTML page to include the fonts.",
     "HOWTO_DIAGRAM_IMAGE"            : "img/ewf-howto-dialog-en.png",
     "HOWTO_DIAGRAM_IMAGE_HIDPI"      : "img/ewf-howto-dialog-en@2x.png",
-    "TERMS_OF_USE"                   : "<a class=\"clickable-link\" data-href=\"http://adobe.com/go/edgewebfonts_tou\">Edge Web Fonts Terms of Use</a>",
+    "TERMS_OF_USE"                   : "<a class=\"clickable-link\" href=\"http://adobe.com/go/edgewebfonts_tou\">Edge Web Fonts Terms of Use</a>",
     "SAMPLE_TEXT"                    : "Sample",
     
     // Font classifications

--- a/package.json
+++ b/package.json
@@ -2,12 +2,19 @@
     "name": "edge-code-web-fonts",
     "title": "Edge Web Fonts extension for Brackets and Edge Code.",
     "description": "Edge Web Fonts gives you access to a vast web font library made possible by contributions from Adobe, Google, and designers around the world. The fonts are served by Typekit, so you can be sure of high performance and stability. Plus, it's free.",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "keywords": [".css", ".html"],
     "homepage": "http://html.adobe.com/edge/webfonts/",
     "bugs": "https://github.com/adobe/brackets-edge-web-fonts/issues",
     "repository" : { 
         "type" : "git",
-         "url" : "https://github.com/adobe/brackets-edge-web-fonts.git"
-    }
+        "url" : "https://github.com/adobe/brackets-edge-web-fonts.git"
+    },
+    "engines": {
+        "brackets": ">=0.30.0"
+    },
+    "keywords": [
+        "css",
+        "html"
+    ]
 }


### PR DESCRIPTION
Brackets used to look for the `data-href` attribute on anchor elements to open external URLs, but now it just looks for good old `href`. This also increases the minimum required engine to Brackets to Sprint 30, lest these links take over the entire Brackets window. 

Addresses #154.

CC @bchintx @larz0 
