### PR TITLE
Clip long font tile labels

### DIFF
--- a/styles/ewf-brackets.css
+++ b/styles/ewf-brackets.css
@@ -197,6 +197,9 @@
   text-align: left;
   line-height: normal;
   padding-top: 0px;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .edge-web-fonts .ewf-picker .wait {
   top: 250px;


### PR DESCRIPTION
Previously font tile labels that didn't fit on the tile would bleed right to the edge of the tile. This explicitly clip long labels with an ellipsis:

![...](http://f.cl.ly/items/423Q041t460H2v1Z3q3a/Screen%20Shot%202013-09-13%20at%2011.28.59%20AM.png)

Addresses #150

Assigning to @larz0
