### PR TITLE
Fix broken EWF Terms of Use link in Getting Started dialog

### DIFF
--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -40,7 +40,7 @@ define({
     "HOWTO_INSTRUCTIONS_4"           : "Paste the embed code into any HTML page to include the fonts.",
     "HOWTO_DIAGRAM_IMAGE"            : "img/ewf-howto-dialog-en.png",
     "HOWTO_DIAGRAM_IMAGE_HIDPI"      : "img/ewf-howto-dialog-en@2x.png",
-    "TERMS_OF_USE"                   : "<a class=\"clickable-link\" href=\"http://adobe.com/go/edgewebfonts_tou\">Edge Web Fonts Terms of Use</a>",
+    "TERMS_OF_USE"                   : "<a href='http://adobe.com/go/edgewebfonts_tou'>Edge Web Fonts Terms of Use</a>",
     "SAMPLE_TEXT"                    : "Sample",
     
     // Font classifications


### PR DESCRIPTION
Replace deprecated "clickable-link" class with simple href.

Related to [pull request #29](https://github.com/edge-code/edge-inspect-extension/pull/30) in the Edge Inspect Extension repo.
