### PR TITLE
Use _.escape() instead of StringUtils.htmlEscape()

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,6 @@ define(function (require, exports, module) {
 
     var AppInit                 = brackets.getModule("utils/AppInit"),
         ExtensionUtils          = brackets.getModule("utils/ExtensionUtils"),
-        StringUtils             = brackets.getModule("utils/StringUtils"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),
         EditorManager           = brackets.getModule("editor/EditorManager"),
         PreferencesManager      = brackets.getModule("preferences/PreferencesManager"),
@@ -48,7 +47,8 @@ define(function (require, exports, module) {
         CommandManager          = brackets.getModule("command/CommandManager"),
         Commands                = brackets.getModule("command/Commands"),
         Dialogs                 = brackets.getModule("widgets/Dialogs"),
-        Menus                   = brackets.getModule("command/Menus");
+        Menus                   = brackets.getModule("command/Menus"),
+        _                       = brackets.getModule("thirdparty/lodash");
     
     // DOM elements and HTML
     var $toolbarIcon = null;
@@ -497,7 +497,7 @@ define(function (require, exports, module) {
             } else {
                 includeString = webfont.createInclude(fontFamilies);
                 var dlg = Dialogs.showModalDialogUsingTemplate(ewfIncludeDialogTemplate);
-                $('.instance .ewf-include-string').html(StringUtils.htmlEscape(includeString)).focus().select();
+                $('.instance .ewf-include-string').html(_.escape(includeString)).focus().select();
             }
         }
         

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "edge-code-web-fonts",
     "title": "Adobe Edge Web Fonts",
     "description": "Adobe Edge Web Fonts gives you access to a free, high-quality web font library made possible by contributions from Adobe, Google, and designers around the world. The fonts are served by Typekit, so you can be sure of high performance and stability.",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "keywords": [".css", ".html"],
     "homepage": "http://html.adobe.com/edge/webfonts/",
     "bugs": "https://github.com/adobe/brackets-edge-web-fonts/issues",


### PR DESCRIPTION
After a long deprecation phase, `StringUtils.htmlEscape()` has been removed. This extension makes use of this removed API. This PR updates it to use `_.escape()` instead to prevent your extension from breaking. Full details are at adobe/brackets#8960.

-le717
